### PR TITLE
feature: add serde support for CLSAG struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/edwinhere/nazgul"
 curve25519-dalek = { version = "4", default-features = false }
 digest = { version = "^0.10", default-features = false }
 rand_core = { version = "^0.6.4", default-features = false }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 sha2 = "^0.10"
@@ -24,7 +25,8 @@ blake2 = "^0.10"
 rand = "^0.8"
 
 [features]
-default = ["std"]
+default = ["std", "serde-derive"]
+serde-derive = ["serde", "curve25519-dalek/serde"]
 std = [
     "digest/std",
     "rand_core/std",

--- a/src/clsag.rs
+++ b/src/clsag.rs
@@ -8,6 +8,9 @@ use digest::Digest;
 use rand_core::{CryptoRng, RngCore};
 use curve25519_dalek::traits::MultiscalarMul;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// Concise Linkable Spontaneous Anonymous Group (CLSAG) signatures
 /// > CLSAG is sort of half-way between bLSAG and MLSAG. Suppose you have a ‘primary’ key, and
 /// associated with it are several ‘auxiliary’ keys. It is important to prove knowledge of all
@@ -16,6 +19,7 @@ use curve25519_dalek::traits::MultiscalarMul;
 ///
 /// Please read tests at the bottom of the source code for this module for examples on how to use
 /// it
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CLSAG {
     /// This is the challenge generated non-interactievely
     pub challenge: Scalar,


### PR DESCRIPTION
- Implement conditional serialization/deserialization using serde when the "serde-derive" feature is enabled.
- Update Cargo.toml to include "serde" adn "curve25519-dalek/serde" as an optional dependency.